### PR TITLE
Add Screen Brightness Helpers

### DIFF
--- a/screen_brightness/INSTALL
+++ b/screen_brightness/INSTALL
@@ -1,0 +1,5 @@
+sudo cp ux581_brightness.{path,service} /etc/systemd/system/
+sudo cp ux581_brightness.sh /usr/local/sbin/
+sudo systemctl enable ux581_brightness.path
+sudo systemctl start ux581_brightness.path
+# Profit!

--- a/screen_brightness/README.md
+++ b/screen_brightness/README.md
@@ -1,0 +1,50 @@
+# Screen Brightness Helpers
+
+## Overview
+The script ux581_brightness.sh reads the currently requested brightness
+and the maximum brightness and generates a percent representation. There
+is a min/max percent brightness for both the OLED and Screenpad displays
+and the percentage is scaled accordingly. The Screenpad brightness is
+then scaled to 0-255 (0x00-0xFF) for the /proc/acpi/call request that
+Plippo documented in s-light#1
+
+The path and service files have been included for SystemD to set up
+inotifywatch on the brightness file and an INSTALL text file has been
+included to show where to place the files and what to run to enable them
+on startup.
+
+Since this is reading the kernel values directly, it is unnecessary to
+make any custom hotkey bindings or set up any custom scripts that need
+to be manually called to change the brightness.
+
+Note that this only currently works with X11. I don't have a system set
+up yet with Wayland and so am not sure if there's an equivalent command
+to xrandr to change the brightness of the OLED screen.
+
+## Required Dependencies
+- acpi_call (kernel module)
+- awk
+- bc
+- getent
+- inotifywait
+- sed
+- xauth
+- xrandr
+
+To install these with Debian based systems
+```
+sudo apt install acpi-call-dkms bc inotify-tools libc-bin sed xauth x11-xserver-utils
+```
+
+Make sure the acpi_call module is loaded
+```
+sudo modprobe acpi_call
+```
+and load this module on startup by appending the following line into `/etc/modules-load.d/modules.conf`
+```
+acpi_call
+```
+
+## Additional info and resources
+- https://github.com/lawleagle/oled-linux
+- https://github.com/s-light/ASUS-ZenBook-Pro-Duo-UX581GV/issues/1

--- a/screen_brightness/ux581_brightness.path
+++ b/screen_brightness/ux581_brightness.path
@@ -1,0 +1,13 @@
+[Unit]
+Description=Watch /sys for Brightness Changes and Update Displays
+ConditionPathExists=/proc/acpi/call
+ConditionPathExists=/sys/class/backlight/intel_backlight/brightness
+ConditionPathExists=/sys/class/backlight/intel_backlight/max_brightness
+ConditionPathExists=/usr/local/sbin/ux581_brightness.sh
+StartLimitIntervalSec=0
+
+[Path]
+PathModified=/sys/class/backlight/intel_backlight/brightness
+
+[Install]
+WantedBy=multi-user.target

--- a/screen_brightness/ux581_brightness.service
+++ b/screen_brightness/ux581_brightness.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Watch /sys for Brightness Changes and Update Displays
+ConditionPathExists=/proc/acpi/call
+ConditionPathExists=/sys/class/backlight/intel_backlight/brightness
+ConditionPathExists=/sys/class/backlight/intel_backlight/max_brightness
+ConditionPathExists=/usr/local/sbin/ux581_brightness.sh
+StartLimitIntervalSec=0
+
+[Service]
+Type=Oneshot
+ExecStart=/usr/local/sbin/ux581_brightness.sh
+User=root
+Group=root

--- a/screen_brightness/ux581_brightness.sh
+++ b/screen_brightness/ux581_brightness.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# Original concept copied and modified from
+# lawleagle: https://github.com/lawleagle/oled-linux
+# Plippo: https://github.com/s-light/ASUS-ZenBook-Pro-Duo-UX581GV/issues/1
+# by Natrinicle
+
+# where is the backlight directory?
+backlight_dir="/sys/class/backlight/intel_backlight/"
+
+# OLED screen brightness range
+min_oled_brightness=10
+max_oled_brightness=100
+
+# Screenpad brightness range
+min_screenpad_brightness=2
+max_screenpad_brightness=100
+
+req_files=( "/proc/acpi/call" "${backlight_dir}/brightness" "${backlight_dir}/max_brightness" )
+for req_file in "${req_files[@]}"; do
+	if ! test -f "${req_file}"; then
+		echo "ERROR: Required file ${req_file} does not exist."
+		exit 1
+	fi
+done
+
+req_cmds=( "awk" "bc" "getent" "inotifywait" "sed" "xauth" "xrandr" )
+for cmd in "${req_cmds[@]}"; do
+  if ! command -v ${cmd} > /dev/null; then
+  	echo "ERROR: Dependency '${cmd}' is not installed. Sorry, but this script cannot run without ${cmd}"
+  	exit 1
+  fi
+done
+
+# Merge all the X11 Xauthority files on the local machine
+for home_dir in $(getent passwd | cut -d: -f6); do
+	if [ -f ${home_dir}/.Xauthority ]; then
+		xauth merge ${home_dir}/.Xauthority
+	fi
+done
+
+# Scale number from old range to new range
+# scale_num_to_range number old_range_lower old_range_upper new_range_lower new_range_upper
+# https://stackoverflow.com/questions/12959371/how-to-scale-numbers-values
+function scale_num_to_range() {
+	echo "${4} + (${5} - ${4}) * (${1} - ${2}) / (${3} - ${2})" | bc -l
+}
+
+function dec_to_hex() {
+	echo "obase=16; ibase=10; ${1}" | bc -l
+}
+
+percent=$(echo "$(cat ${backlight_dir}/brightness) / $(cat ${backlight_dir}/max_brightness) * 100" | bc -l)
+
+oled_percent=$(scale_num_to_range ${percent} 0 100 ${min_oled_brightness} ${max_oled_brightness})
+oled_bright=$(echo "${oled_percent} / 100" | bc -l)
+
+screenpad_percent=$(scale_num_to_range ${percent} 0 100 ${min_screenpad_brightness} ${max_screenpad_brightness})
+screenpad_bright=$(scale_num_to_range ${screenpad_percent} 0 100 0 255 | awk '{printf("%d\n",$1 + 0.5)}' | bc)
+screnpad_hex=$(dec_to_hex ${screenpad_bright} | sed -e :a -e 's/^.\{1,1\}$/0&/;ta')
+
+# Run xrandr on all the X11 displays targeting the correct output for the Asus ZenBook OLED display
+for x11_display in $(for x in /tmp/.X11-unix/X*; do echo ":${x#/tmp/.X11-unix/X}"; done); do
+	DISPLAY=${x11_display} xrandr --output eDP-1 --brightness ${oled_bright} > /dev/null 2>&1
+done
+
+echo "\_SB.ATKD.WMNB 0x0 0x53564544 b32000500${screnpad_hex}000000" > /proc/acpi/call


### PR DESCRIPTION
The script ux581_brightness.sh reads the currently requested brightness
and the maximum brightness and generates a percent representation. There
is a min/max percent brightness for both the OLED and Screenpad displays
and the percentage is scaled accordingly. The Screenpad brightness is
then scaled to 0-255 (0x00-0xFF) for the /proc/acpi/call request that
Plippo documented in s-light#1

The path and service files have been included for SystemD to set up
inotifywatch on the brightness file and an INSTALL text file has been
included to show where to place the files and what to run to enable them
on startup.