### PR TITLE
Add GDM Paths to Xauthority File

### DIFF
--- a/screen_brightness/ux581_brightness.sh
+++ b/screen_brightness/ux581_brightness.sh
@@ -38,6 +38,11 @@ for home_dir in $(getent passwd | cut -d: -f6); do
 		xauth merge ${home_dir}/.Xauthority
 	fi
 done
+for uid in $(getent passwd | cut -d: -f3); do
+	if [ -f /run/user/${uid}/gdm/Xauthority ]; then
+		xauth merge /run/user/${uid}/gdm/Xauthority
+	fi
+done
 
 # Scale number from old range to new range
 # scale_num_to_range number old_range_lower old_range_upper new_range_lower new_range_upper

--- a/screen_brightness/ux581_brightness.sh
+++ b/screen_brightness/ux581_brightness.sh
@@ -14,8 +14,8 @@ max_oled_brightness=100
 oled_monitor_regex="eDP[0-9\-]+"
 
 # Screenpad brightness range & adjustment
-# Mapping is percent called for:Percent screenpad should be lit
-# e.g. 50:75 means when 50% brightness is asked for, set the screenpad to 75%
+# Mapping is percent called for:Amount screenpad should be lit
+# e.g. 50:128 means when 50% brightness is asked for, set the screenpad to 128 out of 255
 screenpad_mapping=( "0:10" "5:13" "50:128" "75:235" "100:255" )
 
 req_files=( "/proc/acpi/call" "${backlight_dir}/brightness" "${backlight_dir}/max_brightness" )

--- a/screen_brightness/ux581_brightness.sh
+++ b/screen_brightness/ux581_brightness.sh
@@ -8,13 +8,15 @@
 # where is the backlight directory?
 backlight_dir="/sys/class/backlight/intel_backlight/"
 
-# OLED screen brightness range
+# OLED screen brightness range & search
 min_oled_brightness=10
 max_oled_brightness=100
+oled_monitor_regex="eDP[0-9\-]+"
 
-# Screenpad brightness range
-min_screenpad_brightness=2
-max_screenpad_brightness=100
+# Screenpad brightness range & adjustment
+# Mapping is percent called for:Percent screenpad should be lit
+# e.g. 50:75 means when 50% brightness is asked for, set the screenpad to 75%
+screenpad_mapping=( "0:10" "5:13" "50:128" "75:235" "100:255" )
 
 req_files=( "/proc/acpi/call" "${backlight_dir}/brightness" "${backlight_dir}/max_brightness" )
 for req_file in "${req_files[@]}"; do
@@ -60,13 +62,37 @@ percent=$(echo "$(cat ${backlight_dir}/brightness) / $(cat ${backlight_dir}/max_
 oled_percent=$(scale_num_to_range ${percent} 0 100 ${min_oled_brightness} ${max_oled_brightness})
 oled_bright=$(echo "${oled_percent} / 100" | bc -l)
 
-screenpad_percent=$(scale_num_to_range ${percent} 0 100 ${min_screenpad_brightness} ${max_screenpad_brightness})
-screenpad_bright=$(scale_num_to_range ${screenpad_percent} 0 100 0 255 | awk '{printf("%d\n",$1 + 0.5)}' | bc)
+# screenpad_percent=$(echo "${percent} * ${screenpad_brightness_scalar} | bc -l")
+max_screenpad_map="${screenpad_mapping[${#screenpad_mapping[@]}-1]}"
+if [ "$(echo "${percent} >= ${max_screenpad_map%%:*}" | bc)" -eq "1" ]; then
+	# Set to max
+	screenpad_percent="${max_screenpad_map##*:}"
+elif [ "$(echo "${percent} <= ${screenpad_mapping[0]%%:*}" | bc)" -eq "1" ]; then
+	screenpad_percent="${screenpad_mapping[0]##*:}"
+else
+	last_x="${screenpad_mapping[0]%%:*}"
+	last_y="${screenpad_mapping[0]##*:}"
+  for mapping in "${screenpad_mapping[@]}"; do
+  	x="${mapping%%:*}"
+  	y="${mapping##*:}"
+		if [ "$(echo "${x} <= 0" | bc)" -eq 1 ] || [ "$(echo "${y} <= 0" | bc)" -eq 1 ]; then
+			# Avoid divide by 0
+			continue
+		fi
+    if [ "$(echo "${percent} > ${x}" | bc)" -eq 1 ]; then
+			screenpad_percent="$(echo "${last_y} + (${percent} - ${last_x}) * (${y} - ${last_y}) / (${x} - ${last_x})" | bc -l)"
+		fi
+		last_x=${x}
+		last_y=${y}
+  done
+fi
+screenpad_bright=$(echo "${screenpad_percent}" | awk '{printf("%d\n",$1 + 0.5)}' | bc)
 screnpad_hex=$(dec_to_hex ${screenpad_bright} | sed -e :a -e 's/^.\{1,1\}$/0&/;ta')
 
 # Run xrandr on all the X11 displays targeting the correct output for the Asus ZenBook OLED display
 for x11_display in $(for x in /tmp/.X11-unix/X*; do echo ":${x#/tmp/.X11-unix/X}"; done); do
-	DISPLAY=${x11_display} xrandr --output eDP-1 --brightness ${oled_bright} > /dev/null 2>&1
+	MONITOR=$(DISPLAY=${x11_display} xrandr --listmonitors | grep -Po "${oled_monitor_regex}" | head -1)
+	DISPLAY=${x11_display} xrandr --output ${MONITOR} --brightness ${oled_bright} > /dev/null 2>&1
 done
 
 echo "\_SB.ATKD.WMNB 0x0 0x53564544 b32000500${screnpad_hex}000000" > /proc/acpi/call


### PR DESCRIPTION
In https://github.com/s-light/ASUS-ZenBook-Pro-Duo-UX581GV/pull/14
@ilikerobots mentioned that GDM places Xauthority in a different
location than KDE. Adding this to get all the Xauthority files merged in
without user intervention.

This is untested code as I don't run GDM but it shouldn't hurt anything
given the file existence test.